### PR TITLE
fix old pip installation from apt

### DIFF
--- a/scripts/dep.sh
+++ b/scripts/dep.sh
@@ -78,7 +78,8 @@ apt-get install -y --reinstall \
     python3-dev \
     python3-pip \
     python-dev \
-    python-pip
+
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py
 
 ## Install pip3 Dependencies
 python3 -m pip install --disable-pip-version-check --upgrade --force-reinstall \


### PR DESCRIPTION
fixed `Package 'python-pip' has no installation candidate`